### PR TITLE
Perl example added

### DIFF
--- a/examples/perl/example.pl
+++ b/examples/perl/example.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 #
 # If you are on Mac OS X do consider installing Perlbrew from http://perlbrew.pl/,
-# then the latest stable Perl and cpan usin git.
+# then the latest stable Perl and cpanm using it.
 #
 # Install Device::BlinkyTape from CPAN
 #


### PR DESCRIPTION
I'm writing Perl support for BlinkyTape. I expect to relese the Perl module to CPAN (the Perl module distribution center) during July. It is already available at  https://github.com/okko/perl-Device-BlinkyTape. This example shows how to use it.

The Perl Module comes with a simulation module that will display a simulated BlinkyTape on the OS X screen. This way development is possible before getting the actual device.
