### PR TITLE
Don't rely on Serial.available() to report the correct/expected value

### DIFF
--- a/ProductionSketch/SerialLoop.cpp
+++ b/ProductionSketch/SerialLoop.cpp
@@ -5,41 +5,32 @@
 
 void serialLoop(CRGB* leds) {
   static int pixelIndex;
-
+  int idx = 0;
+  uint8_t buffer[3];
   while(true) {
-
-    if(Serial.available() > 2) {
-
-      uint8_t buffer[3]; // Buffer to store three incoming bytes used to compile a single LED color
-
-      for (uint8_t x=0; x<3; x++) { // Read three incoming bytes
-        uint8_t c = Serial.read();
-        
-        if (c < 255) {
-          buffer[x] = c; // Using 255 as a latch semaphore
-        }
-        else {
-          LEDS.show();
-          pixelIndex = 0;
-          
-          // BUTTON_IN (D10):   07 - 0111
-          // EXTRA_PIN_A(D7):          11 - 1011
-          // EXTRA_PIN_B (D11):        13 - 1101
-          // ANALOG_INPUT (A9): 14 - 1110
-
-          char c = (digitalRead(BUTTON_IN)    << 3)
-                 | (digitalRead(EXTRA_PIN_A)  << 2)
-                 | (digitalRead(EXTRA_PIN_B)  << 1)
-                 | (digitalRead(ANALOG_INPUT)     );
-          Serial.write(c);
-          
-          break;
-        }
-
-        if (x == 2) {   // If we received three serial bytes
+    if (Serial.available()) {
+      uint8_t c = Serial.read();
+      if (c == 255) {
+	LEDS.show();
+	pixelIndex = 0;
+	idx = 0;   
+	// BUTTON_IN (D10):   07 - 0111
+	// EXTRA_PIN_A(D7):          11 - 1011
+	// EXTRA_PIN_B (D11):        13 - 1101
+	// ANALOG_INPUT (A9): 14 - 1110
+	
+	char c = (digitalRead(BUTTON_IN)    << 3)
+	  | (digitalRead(EXTRA_PIN_A)  << 2)
+	  | (digitalRead(EXTRA_PIN_B)  << 1)
+	  | (digitalRead(ANALOG_INPUT)     );
+	Serial.write(c);
+      } else {        
+        buffer[idx++] = Serial.read();
+        if (idx == 3) {
           if(pixelIndex == LED_COUNT) break; // Prevent overflow by ignoring the pixel data beyond LED_COUNT
           leds[pixelIndex] = CRGB(buffer[0], buffer[1], buffer[2]);
           pixelIndex++;
+          idx = 0;
         }
       }
     }


### PR DESCRIPTION
I don't know if the problem lies with the Serial library or elsewhere, but Serial.available() was never returning a value greater than 1 on my blinkytape. This rewrites the serial loop to incrementally fill the pixel buffer without relying on Serial.available() behaving as expected.

(Symptom: Blinkytape freezes on serial data and does not accept further data.)

(Also, the registration page of your forums are broken. :P)
